### PR TITLE
feat: replace `Promise.allSettled` with `Promise.all` for compatibility reason

### DIFF
--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -29,7 +29,7 @@ export class SimpleSynchronizer {
 
   private async executeBatch(executor: ExecutorFn, commands: string[]) {
     const jobs = commands.map((command) => executor(command));
-    await Promise.allSettled(jobs);
+    await Promise.all(jobs);
   }
 }
 


### PR DESCRIPTION
`Promise.allSettled` is somewhat new, which make the executor handler not work in a lots of environment. Replace with `Promise.all` since we also want to fail as soon as an error is found.